### PR TITLE
fixes #8915

### DIFF
--- a/fastlane/lib/fastlane/setup/crashlytics_beta.rb
+++ b/fastlane/lib/fastlane/setup/crashlytics_beta.rb
@@ -55,7 +55,7 @@ module Fastlane
 
 # rubocop:disable Style/IndentationConsistency
 %{  #
-  # Learn more here: https://github.com/fastlane/setups/blob/master/samples-ios/distribute-beta-build.md 🚀
+  # Learn more here: https://github.com/fastlane/examples 🚀
   #
   lane :beta do |values|
     # Fabric generated this lane for deployment to Crashlytics Beta


### PR DESCRIPTION
changed link to https://github.com/fastlane/examples instead of https://github.com/fastlane/setups/blob/master/samples-ios/distribute-beta-build.md

### Checklist
- [X] I've run `bundle exec rspec` from the root directory to see all new and existing tests pass
- [X] I've followed the _fastlane_ code style and run `bundle exec rubocop -a` to ensure the code style is valid
- [X] I've read the [Contribution Guidelines](https://github.com/fastlane/fastlane/blob/master/CONTRIBUTING.md)
- [X] I've updated the documentation if necessary.